### PR TITLE
Reduce scope of pull-requests permission to be job-specific

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -8,9 +8,6 @@ name: pull request
     types:
       - checks_requested
 
-permissions:
-  pull-requests: read
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
@@ -18,6 +15,8 @@ concurrency:
 jobs:
   detect_changed_files:
     name: detect changed files
+    permissions:
+      pull-requests: read
     uses: ./.github/workflows/detect-changed-files.yml
 
   github_actions:


### PR DESCRIPTION
No need to have the escalated priviledges available to the other jobs when it's not actually used.